### PR TITLE
fix(DistrictLayer): 静态属性命名错误

### DIFF
--- a/types/layers/DistrictLayer.d.ts
+++ b/types/layers/DistrictLayer.d.ts
@@ -69,12 +69,12 @@ export declare class DistrictLayer extends TileLayer {
    */
   getStyle(): DistrictLayerStyle | undefined;
 
-  static Word: typeof WordLayer;
+  static World: typeof WorldLayer;
   static Country: typeof CountryLayer;
   static Province: typeof ProvinceLayer;
 }
 
-declare class WordLayer extends DistrictLayer {}
+declare class WorldLayer extends DistrictLayer {}
 declare class CountryLayer extends DistrictLayer {}
 declare class ProvinceLayer extends DistrictLayer {}
 

--- a/types/layers/DistrictLayer.test-d.ts
+++ b/types/layers/DistrictLayer.test-d.ts
@@ -77,8 +77,8 @@ expectType<void>(layer.setStyles({} as any as DistrictLayerStyle));
 expectType<DistrictLayerStyle | undefined>(layer.getStyle());
 
 // Sub class
-const wordLayer = new DistrictLayer.Word({});
-expectAssignable<DistrictLayer>(wordLayer);
+const worldLayer = new DistrictLayer.World({});
+expectAssignable<DistrictLayer>(worldLayer);
 
 const countryLayer = new DistrictLayer.Country({});
 expectAssignable<DistrictLayer>(countryLayer);


### PR DESCRIPTION
`DistrictLayer.Word` -> `DistrictLayer.World`

Fix #9