### PR TITLE
fix(namespace AMap): 未声明 LabelsLayer 相关的类型

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -27,6 +27,7 @@ import {
   DistrictLayerOptions,
 } from './layers/DistrictLayer';
 import { VectorLayer, VectorLayerOption } from './layers/VectorLayer';
+import { LabelsLayer, LabelsLayerOption } from './layers/LabelsLayer';
 import { CustomLayer, CustomLayerOption } from './layers/CustomLayer';
 import { ImageLayer, ImageLayerOption } from './layers/ImageLayer';
 import { CanvasLayer, CanvasLayerOption } from './layers/CanvasLayer';
@@ -216,6 +217,8 @@ declare global {
       // 自有数据图层
       VectorLayer,
       type VectorLayerOption,
+      LabelsLayer,
+      type LabelsLayerOption,
       CustomLayer,
       type CustomLayerOption,
       ImageLayer,


### PR DESCRIPTION
未声明 LabelsLayer 相关的类型导致 `window.AMap.LabelsLayer` 失效

Resolve #14