### PR TITLE
fix(window.AMap): 工具相关的 API 不存在 window.AMap.GeometryUtil 类型上

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -342,14 +342,19 @@ declare global {
       type ToolBarConfig,
 
       // 工具
-      type GeometryUtil,
-      type Browser,
-      type Util,
-      type DomUtil,
+      // type GeometryUtil,
+      // type Browser,
+      // type Util,
+      // type DomUtil,
 
       // others
       type SecurityConfig,
     };
+
+    export const GeometryUtil: GeometryUtil;
+    export const Browser: Browser;
+    export const Util: Util;
+    export const DomUtil: DomUtil;
 
     export const version: string;
 


### PR DESCRIPTION
AMap.GeometryUtil, AMap.Browser, AMap.Util, AMap.DomUtil 均存在同样的问题

Resolve #13