### PR TITLE
fix(MoveAnimation): easing 属性为非必填项

### DIFF
--- a/types/animates/MoveAnimation.d.ts
+++ b/types/animates/MoveAnimation.d.ts
@@ -30,8 +30,11 @@ export type MoveAlongOptions = {
    * @deprecated 已废弃
    * */
   speed?: number | AnimationCallback;
-  /** easing 时间函数 */
-  easing: EasingCallback;
+  /**
+   * easing 时间函数
+   * TODO: https://github.com/xyy94813/amap-jsapi-v2-types/issues/21#issuecomment-2135147341
+   **/
+  easing?: EasingCallback;
   /** 是否循环 */
   circlable?: boolean;
   /** 延迟动画时长 */

--- a/types/animates/MoveAnimation.d.ts
+++ b/types/animates/MoveAnimation.d.ts
@@ -13,8 +13,11 @@ export type MoveToOptions = {
    * @deprecated 已废弃
    * */
   speed?: number | AnimationCallback;
-  /** easing 时间函数 */
-  easing: EasingCallback;
+  /**
+   * easing 时间函数，未设置时为 Linear
+   * TODO: https://github.com/xyy94813/amap-jsapi-v2-types/issues/21#issuecomment-2135147341
+   */
+  easing?: EasingCallback;
   /** 覆盖物是否沿路径旋转 */
   autoRotation?: boolean;
 };

--- a/types/animates/MoveAnimation.test-d.ts
+++ b/types/animates/MoveAnimation.test-d.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-confusing-void-expression */
 /* eslint-disable @typescript-eslint/no-invalid-void-type */
-import { expectAssignable, expectNotAssignable, expectType } from 'tsd';
+import { expectAssignable, expectType } from 'tsd';
 import {
   AnimationCallback,
   EasingCallback,
@@ -22,8 +22,7 @@ expectAssignable<AnimationCallback>((index, data) => {
 expectAssignable<EasingCallback>(() => 1);
 expectAssignable<EasingCallback>((passedTime) => passedTime ?? 100);
 
-expectNotAssignable<MoveToOptions>({});
-expectAssignable<MoveToOptions>({ easing: () => 1 });
+expectAssignable<MoveToOptions>({ });
 
 expectAssignable<MoveToOptions['duration']>(100);
 expectAssignable<MoveToOptions['speed']>(100);
@@ -32,9 +31,7 @@ expectAssignable<MoveToOptions['speed']>(() => 1);
 expectAssignable<MoveToOptions['easing']>(((passedTime) => passedTime ?? 100));
 expectAssignable<MoveToOptions['autoRotation']>(false);
 
-expectNotAssignable<MoveAlongOptions>({});
 expectAssignable<MoveAlongOptions>({
-  easing: () => 1,
   aniInterval: 100,
 });
 


### PR DESCRIPTION
- MoveToOptions 的 easing 属性非必填
- MoveAlongOptions 的 easing 属性非必填

Fix #21 