### PR TITLE
feat(labels-layer): 支持使用范型约束方法的传参和返回值

### DIFF
--- a/types/layers/LabelsLayer.d.ts
+++ b/types/layers/LabelsLayer.d.ts
@@ -1,4 +1,3 @@
-import type { VectorOverlay } from '../overlays/VectorOverlay';
 import type { LabelMarker } from '../overlays/LabelMarker';
 
 import type { BaseLayer, CommonLayerOptions } from './BaseLayer';
@@ -16,7 +15,9 @@ export type LabelsLayerOption = CommonLayerOptions & {
  *
  * @example new AMap.LabelsLayer(opts: LabelsLayerOptions)
  */
-export declare class LabelsLayer extends BaseLayer {
+export declare class LabelsLayer<
+  TOverlayType extends LabelMarker = LabelMarker
+> extends BaseLayer {
   constructor(options?: LabelsLayerOption);
 
   /**
@@ -41,18 +42,18 @@ export declare class LabelsLayer extends BaseLayer {
   setAllowCollision(allowCollision: boolean): void;
   /**
    * 将 labelMarker 添加到标注层上
-   * @param {LabelMarker | LabelMarker[]} labelMarkers
+   * @param {TOverlayType | TOverlayType[]} labelMarkers
    */
-  add(labelMarkers: LabelMarker | LabelMarker[]): void;
+  add(labelMarkers: TOverlayType | TOverlayType[]): void;
   /**
    * 将 labelMarker 从标注层上移除
-   * @param {LabelMarker | LabelMarker[]} labelMarkers
+   * @param {TOverlayType | TOverlayType[]} labelMarkers
    */
-  remove(labelMarkers: LabelMarker | LabelMarker[]): void;
+  remove(labelMarkers: TOverlayType | TOverlayType[]): void;
   /**
    * 获取标注层内的所有标注对象
    */
-  getAllOverlays(): VectorOverlay[] | undefined;
+  getAllOverlays(): TOverlayType[] | undefined;
   /**
    * 清空 VectorLayer
    */

--- a/types/layers/LabelsLayer.test-d.ts
+++ b/types/layers/LabelsLayer.test-d.ts
@@ -1,8 +1,7 @@
 /* eslint-disable @typescript-eslint/no-confusing-void-expression */
 /* eslint-disable @typescript-eslint/no-invalid-void-type */
-import { expectAssignable, expectType } from 'tsd';
+import { expectAssignable, expectError, expectType } from 'tsd';
 import LabelMarker from '../overlays/LabelMarker';
-import { VectorOverlay } from '../overlays/VectorOverlay';
 import { BaseLayer } from './BaseLayer';
 import {
   LabelsLayerOption,
@@ -41,6 +40,23 @@ expectType<void>(layer.remove(labelMarker));
 expectType<void>(layer.remove([]));
 expectType<void>(layer.remove([labelMarker]));
 
-expectType<VectorOverlay[] | undefined>(layer.getAllOverlays());
+expectType<LabelMarker[] | undefined>(layer.getAllOverlays());
 
 expectType<void>(layer.clear());
+
+
+declare class LabelMarker2 extends LabelMarker {
+  a: string
+}
+
+// 验证自定义范型
+const layer2 = new LabelsLayer<LabelMarker2>();
+expectType<void>(layer2.add([]));
+expectType<void>(layer.remove([]));
+
+expectError<void>(layer2.add(labelMarker));
+expectError<void>(layer2.add([labelMarker]));
+expectError<void>(layer2.remove(labelMarker));
+expectError<void>(layer2.remove([labelMarker]));
+
+expectType<LabelMarker2[]>(layer2.getAllOverlays()!);


### PR DESCRIPTION
以下方法受到影响:

- `add`
- `remove`
- `getAllOverlays`

Resolve #27